### PR TITLE
Add pagination support with limit and offset in QueryBuilder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,10 @@
         {
             "name": "Markus Mauksch",
             "email": "markus.mauksch@ea-energie.de"
+        },
+        {
+          "name": "Alina Scholz",
+          "email": "alina.scholz[aet]ea-energie.de"
         }
     ],
     "minimum-stability": "stable",

--- a/src/Contract/Extensions/Limit.php
+++ b/src/Contract/Extensions/Limit.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Contract\Extensions;
+
+interface Limit
+{
+    public function getLimit() : ?int;
+}

--- a/src/Contract/Extensions/Offset.php
+++ b/src/Contract/Extensions/Offset.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Contract\Extensions;
+
+interface Offset
+{
+    public function getOffset() : int;
+}

--- a/src/Filter/QueryStyle/QueryBuilder.php
+++ b/src/Filter/QueryStyle/QueryBuilder.php
@@ -3,6 +3,8 @@
 namespace Mmauksch\JsonRepositories\Filter\QueryStyle;
 
 use Mmauksch\JsonRepositories\Contract\Extensions\FastFilter;
+use Mmauksch\JsonRepositories\Contract\Extensions\Limit;
+use Mmauksch\JsonRepositories\Contract\Extensions\Offset;
 use Mmauksch\JsonRepositories\Contract\Extensions\Sorter;
 use Mmauksch\JsonRepositories\Filter\QueryStyle\Elements\Condition;
 use Mmauksch\JsonRepositories\Filter\QueryStyle\Elements\ConditionGroup;
@@ -13,7 +15,7 @@ use Mmauksch\JsonRepositories\Filter\QueryStyle\Elements\SortOrder;
 use Mmauksch\JsonRepositories\Filter\QueryStyle\Elements\WhereBuilder;
 use Mmauksch\JsonRepositories\Filter\SortableFilter;
 
-class QueryBuilder implements FastFilter, SortableFilter
+class QueryBuilder implements FastFilter, SortableFilter, Limit, Offset
 {
     /** @var string[][] */
     private array $equalIndexesValues;
@@ -25,6 +27,8 @@ class QueryBuilder implements FastFilter, SortableFilter
     private Sorter $sorter;
     /** @var SortingStep[] */
     private array $sorting = [];
+    private ?int $limit;
+    private int $offset;
 
     public function __construct()
     {
@@ -33,6 +37,8 @@ class QueryBuilder implements FastFilter, SortableFilter
         $this->sorter = new QuerySorter();
         $this->sorting = [];
         $this->root = new ConditionGroup(ConditionGroupType::AND);
+        $this->limit = null;
+        $this->offset = 0;
     }
 //
 //    public function select(array $fields): self
@@ -56,6 +62,18 @@ class QueryBuilder implements FastFilter, SortableFilter
     public function orderBy(string $attribute, SortOrder|string $direction = "asc"): self {
         $orderDirection = $direction instanceof SortOrder? $direction : SortOrder::fromString($direction);
         $this->sorting[] = new SortingStep($attribute, $orderDirection);
+        return $this;
+    }
+
+    public function limit(int $limit): self
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function offset(int $offset): self
+    {
+        $this->offset = $offset;
         return $this;
     }
 
@@ -112,4 +130,13 @@ class QueryBuilder implements FastFilter, SortableFilter
         return $this->sorter;
     }
 
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
 }

--- a/src/Repository/AbstractJsonRepository.php
+++ b/src/Repository/AbstractJsonRepository.php
@@ -4,12 +4,15 @@ namespace Mmauksch\JsonRepositories\Repository;
 
 use Closure;
 use Mmauksch\JsonRepositories\Contract\Extensions\Filter;
+use Mmauksch\JsonRepositories\Contract\Extensions\Limit;
+use Mmauksch\JsonRepositories\Contract\Extensions\Offset;
 use Mmauksch\JsonRepositories\Contract\Extensions\SortableJsonRepository;
 use Mmauksch\JsonRepositories\Contract\Extensions\Sorter;
 use Mmauksch\JsonRepositories\Contract\JsonRepository;
 use Mmauksch\JsonRepositories\Filter\SortableFilter;
 use Mmauksch\JsonRepositories\Repository\Traits\BasicJsonRepositoryTrait;
 use Mmauksch\JsonRepositories\Repository\Traits\FilterableJsonRepositoryTrait;
+use Mmauksch\JsonRepositories\Repository\Traits\LimitAndOffsetTrait;
 use Mmauksch\JsonRepositories\Repository\Traits\SortableJsonRepositoryTrait;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
@@ -22,7 +25,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 abstract class AbstractJsonRepository implements JsonRepository, SortableJsonRepository
 {
-    use BasicJsonRepositoryTrait, FilterableJsonRepositoryTrait, SortableJsonRepositoryTrait;
+    use BasicJsonRepositoryTrait, FilterableJsonRepositoryTrait, SortableJsonRepositoryTrait, LimitAndOffsetTrait;
     protected string $objectSubdir;
     protected string $jsonDbBase;
 
@@ -42,6 +45,7 @@ abstract class AbstractJsonRepository implements JsonRepository, SortableJsonRep
     public function findMatchingFilterObjectSorted(Filter|Closure $filter, Sorter|Closure $sorter) : iterable
     {
         $unsorted = $this->findMatchingFilter($filter);
-        return $this->sortResults($unsorted, $sorter);
+        $sorted = $this->sortResults($unsorted, $sorter);
+        return $this->applyLimitAndOffset($filter, $sorted);
     }
 }

--- a/src/Repository/HighPerformanceJsonRepository.php
+++ b/src/Repository/HighPerformanceJsonRepository.php
@@ -145,7 +145,7 @@ class HighPerformanceJsonRepository extends GenericJsonRepository
 
         $result = [];
         if (empty($usableIndexes)) {
-            $result = parent::findMatchingFilter($filter);
+            return parent::findMatchingFilter($filter);
         }else{
             $files = $this->intersectFilesOfIndexDirectories($filterIndexes, $usableIndexes);
             foreach ($files as $file) {
@@ -158,10 +158,10 @@ class HighPerformanceJsonRepository extends GenericJsonRepository
 
         if ($filter instanceof SortableFilter) {
             $sorter = $filter->getSorter();
-            return $this->sortResults($result, $sorter);
+            $result = $this->sortResults($result, $sorter);
         }
 
-        return $result;
+        return $this->applyLimitAndOffset($filter, $result);
     }
 
     /** @param T $object */

--- a/src/Repository/Traits/FilterableJsonRepositoryTrait.php
+++ b/src/Repository/Traits/FilterableJsonRepositoryTrait.php
@@ -14,7 +14,7 @@ use Symfony\Component\Finder\Finder;
  */
 trait FilterableJsonRepositoryTrait
 {
-    use BasicJsonRepositoryTrait;
+    use BasicJsonRepositoryTrait, LimitAndOffsetTrait;
     public function findMatchingFilter(Filter|Closure $filter): iterable
     {
         $result = [];
@@ -26,9 +26,9 @@ trait FilterableJsonRepositoryTrait
 
         if ($filter instanceof SortableFilter) {
             $sorter = $filter->getSorter();
-            return $this->sortResults($result, $sorter);
+            $result = $this->sortResults($result, $sorter);
         }
-        return $result;
+        return $this->applyLimitAndOffset($filter, $result);
     }
 
     public function deleteMatchingFilter(Filter|Closure $filter): void

--- a/src/Repository/Traits/LimitAndOffsetTrait.php
+++ b/src/Repository/Traits/LimitAndOffsetTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Repository\Traits;
+
+use Closure;
+use Mmauksch\JsonRepositories\Contract\Extensions\Filter;
+use Mmauksch\JsonRepositories\Contract\Extensions\Limit;
+use Mmauksch\JsonRepositories\Contract\Extensions\Offset;
+
+trait LimitAndOffsetTrait
+{
+    /**
+     * @param Filter|Closure $filter
+     * @param array $sorted
+     * @return array
+     */
+    public function applyLimitAndOffset(Filter|Closure $filter, array $sorted): array
+    {
+        $offset = $filter instanceof Offset ? $filter->getOffset() : 0;
+        if (!$filter instanceof Limit) {
+            return $sorted;
+        }
+        $reduced = array_slice($sorted, $offset, $filter->getLimit());
+        return $reduced;
+    }
+
+}

--- a/src/Repository/Traits/SortableJsonRepositoryTrait.php
+++ b/src/Repository/Traits/SortableJsonRepositoryTrait.php
@@ -19,7 +19,7 @@ trait SortableJsonRepositoryTrait
         return $this->sortResults($allObjects, $sorter);
     }
 
-    protected function sortResults(array $unsorted, Sorter|Closure $sorter) : iterable
+    protected function sortResults(array $unsorted, Sorter|Closure $sorter) : array
     {
         usort($unsorted, $sorter);
         return $unsorted;

--- a/tests/Repository/GenericRepositoryTest.php
+++ b/tests/Repository/GenericRepositoryTest.php
@@ -347,6 +347,38 @@ class GenericRepositoryTest extends TestCase
 
     }
 
+    public function testQueryStyleWithLimit()
+    {
+        $toSave = [self::ObjectFirst(), self::ObjectSecond(), self::ObjectThird()];
+        foreach($toSave as $object) {
+            $this->instance->saveObject($object, $object->getId());
+        }
+
+        $query = (new QueryBuilder())->where()
+            ->condition('name', '=', 'aa-first-name')
+            ->end()
+            ->orderBy('id', 'asc')->limit(1);;
+        $result = $this->instance->findMatchingFilter($query);
+        $this->assertCount(1, $result);
+        $this->assertEquals($toSave[0]->getId(), $result[0]->getId());
+
+
+        $query = (new QueryBuilder())->where()
+            ->condition('name', '=', 'aa-first-name')
+            ->end()
+            ->orderBy('id', 'asc')->limit(1)->offset(1);
+        $result = $this->instance->findMatchingFilter($query);
+        $this->assertCount(1, $result);
+        $this->assertEquals($toSave[2]->getId(), $result[0]->getId());
+
+        $query = (new QueryBuilder())
+            ->orderBy('id', 'asc')->limit(2)->offset(1);
+        $result = $this->instance->findMatchingFilter($query);
+        $this->assertCount(2, $result);
+        $this->assertEquals($toSave[1]->getId(), $result[0]->getId());
+        $this->assertEquals($toSave[2]->getId(), $result[1]->getId());
+
+    }
 
 
 }


### PR DESCRIPTION
### Description of Changes

- Introduced `Limit` and `Offset` interfaces to define pagination behavior.
- Implemented `LimitAndOffsetTrait` to apply limit and offset for filtering.
- Extended `QueryBuilder` with `limit` and `offset` methods.
- Updated repositories to integrate limit and offset functionalities.
- Added tests to validate limit, offset, and combined query behaviors.

### Checklist

- [x] My changes require updates to documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.