### PR TITLE
Add multi-repository join support to QueryBuilder

### DIFF
--- a/src/Contract/Extensions/Reset.php
+++ b/src/Contract/Extensions/Reset.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Contract\Extensions;
+
+interface Reset
+{
+    public function reset() : void;
+}

--- a/src/Filter/QueryStyle/Elements/Condition.php
+++ b/src/Filter/QueryStyle/Elements/Condition.php
@@ -2,6 +2,8 @@
 
 namespace Mmauksch\JsonRepositories\Filter\QueryStyle\Elements;
 
+use function PHPUnit\Framework\stringContains;
+
 class Condition
 {
     use GetPropertyValueTrait;
@@ -15,17 +17,50 @@ class Condition
         $this->value = $value;
     }
 
-    public function evaluate(object $data): bool
+    /**
+     * @param object $data
+     * @param array<string, array|iterable> $joinSet
+     * @return bool
+     */
+    public function evaluate(object $data, array $joinSet): bool
     {
-        $actual = $this->getValue($data, $this->attribute);
+
+
+        $actual = $this->getValueWithJoins($data, $this->attribute, $joinSet);
+
+        $value = $this->value;
+        if ($value instanceof RefAttribute) {
+            $value = $this->getValueWithJoins($data, $value, $joinSet);
+        }
 
         return match ($this->operation) {
-            Operation::EQ  => $actual == $this->value,
-            Operation::NEQ => $actual != $this->value,
-            Operation::GT  => $actual > $this->value,
-            Operation::GTE => $actual >= $this->value,
-            Operation::LT  => $actual < $this->value,
-            Operation::LTE => $actual <= $this->value,
+            Operation::EQ  => $actual ==  $value,
+            Operation::NEQ => $actual !=  $value,
+            Operation::GT  => $actual >   $value,
+            Operation::GTE => $actual >=  $value,
+            Operation::LT  => $actual <   $value,
+            Operation::LTE => $actual <=  $value,
         };
     }
+
+//    /**
+//     * @param object $data
+//     * @param array<string, array|iterable> $joinSet
+//     * @return bool
+//     */
+//    private function evaluateLeftOwnRefs(object $data, array $joinSet)
+//    {
+//
+//    }
+//    /**
+//     * @param object $data
+//     * @param array $joinSet
+//     * @return bool
+//     */
+//    private function evaluateLeftForeignRefs(object $data, array $joinSet)
+//    {
+//
+//    }
+
+
 }

--- a/src/Filter/QueryStyle/Elements/ConditionGroup.php
+++ b/src/Filter/QueryStyle/Elements/ConditionGroup.php
@@ -26,11 +26,16 @@ class ConditionGroup
         $this->conditions[] = $conditionGroup;
     }
 
-    public function evaluate(object $data): bool
+    /**
+     * @param object $data
+     * @param array<string, array|iterable> $joinSet
+     * @return bool
+     */
+    public function evaluate(object $data, array $joinSet = []): bool
     {
         if ($this->type === ConditionGroupType::AND) {
             foreach ($this->conditions as $c) {
-                if (!$c->evaluate($data)) {
+                if (!$c->evaluate($data, $joinSet)) {
                     return false;
                 }
             }
@@ -39,7 +44,7 @@ class ConditionGroup
 
         if ($this->type === ConditionGroupType::OR) {
             foreach ($this->conditions as $c) {
-                if ($c->evaluate($data)) {
+                if ($c->evaluate($data, $joinSet)) {
                     return true;
                 }
             }
@@ -48,4 +53,5 @@ class ConditionGroup
 
         throw new \LogicException("Unknown group type: " . $this->type->value);
     }
+
 }

--- a/src/Filter/QueryStyle/Elements/GetPropertyValueTrait.php
+++ b/src/Filter/QueryStyle/Elements/GetPropertyValueTrait.php
@@ -4,8 +4,12 @@ namespace Mmauksch\JsonRepositories\Filter\QueryStyle\Elements;
 
 trait GetPropertyValueTrait
 {
-    private function getValue(object $data, string $attr): mixed
+    private function getValue(array|object $data, string $attr): mixed
     {
+        if (is_array($data)) {
+            return $data[$attr] ?? null;
+        }
+
         $publicProps = get_object_vars($data); // nur public, kein Fatal
         if (array_key_exists($attr, $publicProps)) {
             return $publicProps[$attr];
@@ -28,5 +32,38 @@ trait GetPropertyValueTrait
         }
 
         return null;
+    }
+//
+//    private function getValueWithJoins(array|object $data, string $attr, array $joinResults): mixed
+//    {
+//        if (str_contains($attr, '.')) {
+//            [$prefix, $subAttr] = explode('.', $attr, 2);
+//
+//            if (isset($joinResults[$prefix])) {
+//                foreach ($joinResults[$prefix] as $joined) {
+//                    $val = $this->getValue($joined, $subAttr);
+//                    if ($val !== null) {
+//                        return $val;
+//                    }
+//                }
+//                return null;
+//            }
+//        }
+//
+//        return $this->getValue($data, $attr);
+//    }
+
+    private function getValueWithJoins(array|object $data, string $attr, array $joinResults): mixed
+    {
+        if (str_contains($attr, '.')) {
+            [$prefix, $subAttr] = explode('.', $attr, 2);
+
+            if (isset($joinResults[$prefix])) {
+                $joined = $joinResults[$prefix];
+                return $this->getValue($joined, $subAttr);
+            }
+        }
+
+        return $this->getValue($data, $attr);
     }
 }

--- a/src/Filter/QueryStyle/Elements/InnerJoinBuilder.php
+++ b/src/Filter/QueryStyle/Elements/InnerJoinBuilder.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Filter\QueryStyle\Elements;
+
+use Mmauksch\JsonRepositories\Filter\QueryStyle\QueryBuilder;
+use Mmauksch\JsonRepositories\Repository\AbstractJsonRepository;
+
+class InnerJoinBuilder
+{
+    const DELIMITER = ".";
+    const TYPE_INTERNAL = "internal";
+    const TYPE_EXTERNAL = "external";
+
+    private QueryBuilder $queryBuilder;
+    private AbstractJsonRepository $repository;
+    private string $name_prefix;
+
+    private ?RefAttribute $joinRepoAttribute;
+    private ?RefAttribute $otherRefAttribute;
+    private ?RefAttribute $noRefAttribute;
+
+    private string $type;
+
+    public function __construct(QueryBuilder $queryBuilder, AbstractJsonRepository $repository, $name_prefix)
+    {
+        $this->queryBuilder = $queryBuilder;
+        $this->repository = $repository;
+        $this->name_prefix = $name_prefix;
+        $this->joinRepoAttribute = null;
+        $this->noRefAttribute = null;
+        $this->otherRefAttribute = null;
+        $this->type = "";
+    }
+
+    public function On(string $left, string $right): QueryBuilder
+    {
+        if(str_starts_with($left, $this->name_prefix.self::DELIMITER)
+            && !str_contains($right, self::DELIMITER)){
+//            $this->joinRepoAttribute = new RefAttribute($this->name_prefix, substr($left, strlen($this->name_prefix) + 1));
+//            $this->noRefAttribute = new RefAttribute(null,$right);
+            $this->joinRepoAttribute = RefAttribute::fromString($left);
+            $this->noRefAttribute = RefAttribute::fromString($right);
+
+            $this->type = self::TYPE_INTERNAL;
+            return $this->queryBuilder;
+        } elseif (str_starts_with($right, $this->name_prefix.self::DELIMITER)
+            && !str_contains($left, self::DELIMITER)){
+//            $this->joinRepoAttribute = new RefAttribute(null, $left);
+//            $this->noRefAttribute = new RefAttribute($this->name_prefix, substr($right, strlen($this->name_prefix) + 1));
+            $this->joinRepoAttribute = RefAttribute::fromString($right);
+            $this->noRefAttribute = RefAttribute::fromString($left);
+
+            $this->type = self::TYPE_INTERNAL;
+            return $this->queryBuilder;
+        }elseif(str_starts_with($left, $this->name_prefix.self::DELIMITER)
+            && str_contains($right, self::DELIMITER)){
+//            $this->joinRepoAttribute = new RefAttribute($this->name_prefix, substr($left, strlen($this->name_prefix) + 1));
+//            $this->otherRefAttribute = new RefAttribute(
+//                substr($right, 0, strpos($right, self::DELIMITER)),
+//                substr($right, strpos($right, self::DELIMITER) + 1));
+            $this->joinRepoAttribute = RefAttribute::fromString( $left);
+            $this->otherRefAttribute = RefAttribute::fromString($right);
+
+            $this->type = self::TYPE_EXTERNAL;
+            return $this->queryBuilder;
+        } elseif (str_starts_with($right, $this->name_prefix.self::DELIMITER)
+            && str_contains($left, self::DELIMITER)){
+//            $this->joinRepoAttribute = new RefAttribute($this->name_prefix, substr($right, strlen($this->name_prefix) + 1));
+//            $this->otherRefAttribute = new RefAttribute(
+//                substr($left, 0, strpos($left, self::DELIMITER)),
+//                substr($left, strpos($left, self::DELIMITER) + 1));
+
+            $this->joinRepoAttribute = RefAttribute::fromString( $right);
+            $this->otherRefAttribute = RefAttribute::fromString($left);
+            $this->type = self::TYPE_EXTERNAL;
+            return $this->queryBuilder;
+        }
+
+        throw new \LogicException("Join conditions broken");
+    }
+
+    /***
+     * @internal This method should only be used by the QueryBuilder itself
+     * @return string
+     */
+    public function __getJoinRepoAttribute(): RefAttribute
+    {
+        return $this->joinRepoAttribute;
+    }
+
+    /***
+     * @internal This method should only be used by the QueryBuilder itself
+     * @return string
+     */
+    public function __getNoRefAttribute(): RefAttribute
+    {
+        return $this->noRefAttribute;
+    }
+
+    /***
+     * @internal This method should only be used by the QueryBuilder itself
+     * @return string
+     */
+    public function __getOtherRefAttribute(): RefAttribute
+    {
+        return $this->otherRefAttribute;
+    }
+
+
+    public function __getRepository(): AbstractJsonRepository
+    {
+        return $this->repository;
+    }
+
+    public function __getType(): string
+    {
+        return $this->type;
+    }
+
+}

--- a/src/Filter/QueryStyle/Elements/RefAttribute.php
+++ b/src/Filter/QueryStyle/Elements/RefAttribute.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Filter\QueryStyle\Elements;
+
+
+class RefAttribute
+{
+
+    const DELIMITER = ".";
+    private ?string $ref;
+    private string $attribute;
+
+    public function __construct(?string $ref, string $attribute) {
+        $this->ref = $ref;
+        $this->attribute = $attribute;
+    }
+
+    public static function isForeignRef(string $checkIfRef): bool
+    {
+        return str_contains($checkIfRef, self::DELIMITER);
+    }
+
+    public static function fromString($string): RefAttribute
+    {
+        if(!self::isForeignRef($string)) {
+            return new RefAttribute(null, $string);
+        }
+
+        return new RefAttribute(
+            substr($string, 0, strpos($string, self::DELIMITER)),
+            substr($string, strpos($string, self::DELIMITER) + 1));
+    }
+
+    public function getRef(): ?string
+    {
+        return $this->ref;
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->attribute;
+    }
+
+    public function __toString(): string
+    {
+        return $this->ref . self::DELIMITER . $this->attribute;
+    }
+
+
+
+}

--- a/src/Filter/QueryStyle/Elements/WhereBuilder.php
+++ b/src/Filter/QueryStyle/Elements/WhereBuilder.php
@@ -18,7 +18,7 @@ class WhereBuilder
     public function condition(string $attribute, Operation|String $operation, mixed $value): self
     {
         $op = $operation instanceof Operation? $operation: Operation::fromString($operation);
-        if ($op == Operation::EQ){
+        if ($op == Operation::EQ && ! $value instanceof RefAttribute){
             $this->parent->addEqualIndexValue($attribute, $value);
         }
         $this->current->add(new Condition($attribute,$op,$value));

--- a/src/Repository/HighPerformanceJsonRepository.php
+++ b/src/Repository/HighPerformanceJsonRepository.php
@@ -207,4 +207,8 @@ class HighPerformanceJsonRepository extends GenericJsonRepository
         }
     }
 
+
+    public function deleteMatchingFilter(Filter|Closure $filter) : void{
+        throw new \Exception("Not implemented");
+    }
 }

--- a/src/Repository/Traits/BasicJsonRepositoryTrait.php
+++ b/src/Repository/Traits/BasicJsonRepositoryTrait.php
@@ -29,6 +29,13 @@ trait BasicJsonRepositoryTrait
         return $object;
     }
 
+    public function getTargetClass(): string
+    {
+        return $this->targetClass;
+    }
+
+
+
     /** @return T[] */
     public function findAllObjects(): array
     {

--- a/tests/TestObjects/CompanyObject.php
+++ b/tests/TestObjects/CompanyObject.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Tests\TestObjects;
+
+class CompanyObject
+{
+    private string $name;
+    private string $address;
+    private string $city;
+    private string $country;
+
+    private ?string $boss;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): CompanyObject
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function setAddress(string $address): CompanyObject
+    {
+        $this->address = $address;
+        return $this;
+    }
+
+    public function getCity(): string
+    {
+        return $this->city;
+    }
+
+    public function setCity(string $city): CompanyObject
+    {
+        $this->city = $city;
+        return $this;
+    }
+
+    public function getCountry(): string
+    {
+        return $this->country;
+    }
+
+    public function setCountry(string $country): CompanyObject
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    public function getBoss(): ?string
+    {
+        return $this->boss;
+    }
+
+    public function setBoss(?string $boss): CompanyObject
+    {
+        $this->boss = $boss;
+        return $this;
+    }
+
+
+}

--- a/tests/TestObjects/CountryObject.php
+++ b/tests/TestObjects/CountryObject.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Tests\TestObjects;
+
+class CountryObject
+{
+    private string $short;
+    private string $long;
+
+    private string $overlord;
+
+    public function getShort(): string
+    {
+        return $this->short;
+    }
+
+    public function setShort(string $short): CountryObject
+    {
+        $this->short = $short;
+        return $this;
+    }
+
+    public function getLong(): string
+    {
+        return $this->long;
+    }
+
+    public function setLong(string $long): CountryObject
+    {
+        $this->long = $long;
+        return $this;
+    }
+
+    public function getOverlord(): string
+    {
+        return $this->overlord;
+    }
+
+    public function setOverlord(string $overlord): CountryObject
+    {
+        $this->overlord = $overlord;
+        return $this;
+    }
+
+
+
+}

--- a/tests/TestObjects/CountryRatingObject.php
+++ b/tests/TestObjects/CountryRatingObject.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mmauksch\JsonRepositories\Tests\TestObjects;
+
+class CountryRatingObject
+{
+    private string $id;
+    private string $rating;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setId(string $id): CountryRatingObject
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getRating(): string
+    {
+        return $this->rating;
+    }
+
+    public function setRating(string $rating): CountryRatingObject
+    {
+        $this->rating = $rating;
+        return $this;
+    }
+
+
+}


### PR DESCRIPTION
- Introduced `InnerJoinBuilder` to facilitate repository joins in `QueryBuilder`.
- Enhanced `PerformanceRepositoryTest` with advanced test cases across `person`, `company`, and `country` repositories.
- Verified filtering capabilities and complex relationship assertions during