### PR TITLE
Add `IN` and `NOT IN` operations to `QueryBuilder`

### DIFF
--- a/src/Filter/QueryStyle/Elements/Operation.php
+++ b/src/Filter/QueryStyle/Elements/Operation.php
@@ -10,10 +10,12 @@ enum Operation: string
     case GTE = '>=';
     case LT = '<';
     case LTE = '<=';
+    case IN = 'IN';
+    case NOT_IN = 'NOT IN';
 
     static function fromString(string $operation): self
     {
-        return self::from($operation);
+        return self::from(mb_strtoupper($operation));
     }
 
 }

--- a/tests/Repository/PerformanceRepositoryTest.php
+++ b/tests/Repository/PerformanceRepositoryTest.php
@@ -119,7 +119,8 @@ class PerformanceRepositoryTest extends TestCase
     {
         return (new CountryObject())
             ->setShort('hell')
-            ->setLong('in all, a funny place')
+            ->setLong('Hellfiretanien')
+            ->setDescription('in all, a funny place')
             ->setOverlord('cc-third-id');
     }
     public static function Country2(): CountryObject
@@ -127,6 +128,7 @@ class PerformanceRepositoryTest extends TestCase
         return (new CountryObject())
             ->setShort('de')
             ->setLong('germany')
+            ->setDescription('germans live here')
             ->setOverlord('bb-second-id');
     }
 
@@ -634,7 +636,7 @@ class PerformanceRepositoryTest extends TestCase
             ->innerJoin($this->companyRepository, "company")
             ->On("company.name", "company")
             ->where()
-            ->condition('country.long', '=', 'in all, a funny place')
+            ->condition('country.long', '=', 'Hellfiretanien')
             ->end();
         $this->assertCount(1, $this->runTestJoinQuery($query));
     }
@@ -651,4 +653,57 @@ class PerformanceRepositoryTest extends TestCase
             ->end();
         $this->assertCount(3, $this->runTestJoinQuery($query));
     }
+
+    public function testINConditions()
+    {
+        $query = (new QueryBuilder())
+            ->where()
+            ->condition('name', Operation::IN, ['nopeName', 'cc-third-name', 'aa-first-name'])
+            ->end();
+        $this->assertCount(2, $this->runTestJoinQuery($query));
+
+        $query = (new QueryBuilder())
+            ->innerJoin($this->companyRepository, "company")
+            ->On("company", "company.name")
+            ->innerJoin($this->countryRepository, "country")
+            ->On("country.short", "company.country")
+            ->where()
+            ->condition('country.long', Operation::IN, ['nopeTan', 'germany'])
+            ->end();
+        $this->assertCount(3, $this->runTestJoinQuery($query));
+
+        $query = (new QueryBuilder())
+            ->innerJoin($this->companyRepository, "company")
+            ->On("company", "company.name")
+            ->innerJoin($this->countryRepository, "country")
+            ->On("country.short", "company.country")
+            ->where()
+            ->condition('country.description', Operation::IN, ['in all, a funny place'])
+            ->end();
+        $this->assertCount(1, $this->runTestJoinQuery($query));
+
+        $query = (new QueryBuilder())
+            ->innerJoin($this->companyRepository, "company")
+            ->On("company", "company.name")
+            ->innerJoin($this->countryRepository, "country")
+            ->On("country.short", "company.country")
+            ->where()
+            ->condition('country.long', Operation::NOT_IN, ['nopeTan', 'germany'])
+            ->end();
+        $this->assertCount(1, $this->runTestJoinQuery($query));
+
+        $query = (new QueryBuilder())
+            ->innerJoin($this->companyRepository, "company")
+            ->On("company", "company.name")
+            ->innerJoin($this->countryRepository, "country")
+            ->On("country.short", "company.country")
+            ->where()
+            ->condition('country.long', Operation::NOT_IN, ['nopeTan', 'germany', 'Hellfiretanien'])
+            ->end();
+        $this->assertCount(0, $this->runTestJoinQuery($query));
+
+
+    }
+
+
 }

--- a/tests/TestObjects/CountryObject.php
+++ b/tests/TestObjects/CountryObject.php
@@ -9,6 +9,8 @@ class CountryObject
 
     private string $overlord;
 
+    private string $description;
+
     public function getShort(): string
     {
         return $this->short;
@@ -39,6 +41,17 @@ class CountryObject
     public function setOverlord(string $overlord): CountryObject
     {
         $this->overlord = $overlord;
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): CountryObject
+    {
+        $this->description = $description;
         return $this;
     }
 


### PR DESCRIPTION
Expand `QueryBuilder` functionality by introducing support for `IN` and `NOT IN` condition types, allowing for efficient handling of array-based queries. Enhance `PerformanceRepositoryTest` to validate new behavior, and update `CountryObject` model to include a description field. Ensure robust test coverage for introduced changes.